### PR TITLE
Add Unique ID to Allow Entity Modification in the UI

### DIFF
--- a/custom_components/ryobi_gdo3/cover.py
+++ b/custom_components/ryobi_gdo3/cover.py
@@ -9,7 +9,7 @@ import voluptuous as vol
 from datetime import timedelta
 
 import homeassistant.helpers.config_validation as cv
-
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.components.cover import (
     CoverEntity, PLATFORM_SCHEMA, SUPPORT_OPEN, SUPPORT_CLOSE)
 from homeassistant.const import (
@@ -67,15 +67,18 @@ class RyobiCover(CoverEntity):
         self.ryobi_door = ryobi_door
         self._name = 'ryobi_gdo_door_{}'.format(ryobi_door.get_device_id())
         self._door_state = None
+        self.device_id = ryobi_door.get_device_id()
+        self._attr_unique_id = 'ryobi_gdo_door_{}'.format(ryobi_door.get_device_id())
       
     @property
-    def device_info(self):
+    def device_info(self) -> DeviceInfo:
         """Return device registry information for this entity."""
-        return {
-            "identifiers": {(DOMAIN, self.device_id)},
-            "manufacturer": "Ryobi",
-            "name": self._name,
-        }
+        return DeviceInfo(
+            identifiers = {(DOMAIN, self.device_id)},
+            manufacturer = "Ryobi",
+            model = "GDO",
+            name = "Ryobi Garage Door Opener",
+        )
 
     @property
     def name(self):

--- a/custom_components/ryobi_gdo3/light.py
+++ b/custom_components/ryobi_gdo3/light.py
@@ -62,9 +62,9 @@ class RyobiLight(LightEntity):
     def __init__(self, hass, ryobi_door):
         """Initialize the light."""
         self.ryobi_door = ryobi_door
-        self.device_id = ryobi_door.get_device_id()
         self._name = 'ryobi_gdo_light_{}'.format(ryobi_door.get_device_id())
         self._light_state = None
+        self.device_id = ryobi_door.get_device_id()
         self._attr_unique_id = 'ryobi_gdo_light_{}'.format(ryobi_door.get_device_id())
       
     @property

--- a/custom_components/ryobi_gdo3/light.py
+++ b/custom_components/ryobi_gdo3/light.py
@@ -9,7 +9,7 @@ import voluptuous as vol
 from datetime import timedelta
 
 import homeassistant.helpers.config_validation as cv
-
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.components.light import (
     LightEntity, PLATFORM_SCHEMA)
 from homeassistant.const import (
@@ -62,17 +62,20 @@ class RyobiLight(LightEntity):
     def __init__(self, hass, ryobi_door):
         """Initialize the light."""
         self.ryobi_door = ryobi_door
+        self.device_id = ryobi_door.get_device_id()
         self._name = 'ryobi_gdo_light_{}'.format(ryobi_door.get_device_id())
         self._light_state = None
+        self._attr_unique_id = 'ryobi_gdo_light_{}'.format(ryobi_door.get_device_id())
       
     @property
-    def device_info(self):
+    def device_info(self) -> DeviceInfo:
         """Return device registry information for this entity."""
-        return {
-            "identifiers": {(DOMAIN, device_id)},
-            "manufacturer": "Ryobi",
-            "name": self._name,
-        }
+        return DeviceInfo( 
+            identifiers = {(DOMAIN, self.device_id)},
+            manufacturer = "Ryobi",
+            model = "GDO",
+            name = "Ryobi Garage Door Opener",
+        )
 
     @property
     def name(self):


### PR DESCRIPTION
This changes set a unique entity ID so we can edit entity attributes in the UI (https://www.home-assistant.io/faq/unique_id/)

This lets you assign a device name in the UI.

![image](https://user-images.githubusercontent.com/552230/210163520-4c97903f-7674-4220-b958-80ef39778e33.png)

I also updated the device_info handler in the hope that the device would be listed under Devices on the dashboard but it did not work, so let me know if you want me to back out that change.

Here's a screenshot where I've updated the device names in the UI:

![image](https://user-images.githubusercontent.com/552230/210163695-c982a0a1-9c6d-4e99-80da-b0da41616cb2.png)
